### PR TITLE
Internationalisation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,9 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.0
 Imports:
+  checkmate,
   crosstalk,
   htmltools,
   htmlwidgets

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,15 @@
 Package: summarywidget
 Title: Display Summary Statistics from Linked Data
 Version: 0.0.0.9000
-Authors@R: person("Kent", "Johnson", email = "kent@kentsjohnson.com", role = c("aut", "cre"))
+Authors@R:
+    c(
+      person("Kent", "Johnson", email = "kent@kentsjohnson.com", role = c("aut", "cre")),
+      person("Gerold", "Hepp", email = "ghepp@iwag.tuwien.ac.at", role = "ctb")
+    )
 Description: SummaryWidget displays a single statistic derived from a linked table. 
-   It's primary use is with the crosstalk package. 
-   Used with crosstalk, a summarywidget displays a value which updates 
-   as the data selection changes.
+    Its primary use is with the crosstalk package. 
+    Used with crosstalk, a summarywidget displays a value which updates 
+    as the data selection changes.
 URL: https://github.com/kent37/summarywidget
 BugReports: https://github.com/kent37/summarywidget/issues
 Depends: R (>= 3.3.2)
@@ -15,11 +19,12 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
 Imports:
-  checkmate,
-  crosstalk,
-  htmltools,
-  htmlwidgets
-Suggests: knitr,
+    checkmate,
+    crosstalk,
+    htmltools,
+    htmlwidgets
+Suggests:
+    knitr,
     rmarkdown,
     DT
 VignetteBuilder: knitr

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,5 +3,6 @@
 export(renderSummarywidget)
 export(summarywidget)
 export(summarywidgetOutput)
+import(checkmate)
 import(crosstalk)
 import(htmlwidgets)

--- a/R/summarywidget.R
+++ b/R/summarywidget.R
@@ -1,3 +1,8 @@
+#' @import checkmate
+#' @import crosstalk
+#' @import htmlwidgets
+NULL
+
 #' Show a single summary statistic in a widget
 #'
 #' A `summarywidget` displays a single statistic derived from a linked table.
@@ -12,17 +17,27 @@
 #' @param selection Expression to select a fixed subset of `data`. May be
 #' a logical vector or a one-sided formula that evaluates to a logical vector.
 #' If used, the `key` given to [crosstalk::SharedData] must be a fixed column (not row numbers).
-#' @param digits Number of decimal places to display, or NULL to display full precision.
-#'
-#' @import crosstalk
-#' @import htmlwidgets
+#' @param locales A locales string accepted by
+#'  \url{https://www.w3schools.com/jsref/jsref_tolocalestring_number.asp}.
+#' @param options A list of options accepted by
+#'  \url{https://www.w3schools.com/jsref/jsref_tolocalestring_number.asp}.
+#'  Ignored if `locales` argument is not supplied.
+#' @param width Currently not used.
+#' @param height Currently not used.
+#' @param elementId Currently not used.
 #'
 #' @export
-#' @seealso \url{https://kent37.github.io/summarywidget}
-summarywidget <- function(data,
-                          statistic=c("count", "sum", "mean"), column = NULL,
-                          selection=NULL, digits=0,
-                          width=NULL, height=NULL, elementId = NULL) {
+summarywidget <- function(
+  data,
+  statistic = c("count", "sum", "mean"),
+  column = NULL,
+  selection = NULL,
+  locales = NULL,
+  options = NULL,
+  width = NULL,
+  height = NULL,
+  elementId = NULL
+) {
 
   if (crosstalk::is.SharedData(data)) {
     # Using Crosstalk
@@ -37,6 +52,14 @@ summarywidget <- function(data,
   }
 
   statistic <- match.arg(statistic)
+
+  if (!is.null(locales)) {
+    qassert(locales, "S1")
+
+    if (!is.null(options)) {
+      qassert(options, "L+")
+    }
+  }
 
   # If selection is given, apply it
   if (!is.null(selection)) {
@@ -69,7 +92,8 @@ summarywidget <- function(data,
     data = data,
     settings = list(
       statistic = statistic,
-      digits = digits,
+      locales = locales,
+      options = options,
       crosstalk_key = key,
       crosstalk_group = group
     )

--- a/R/summarywidget.R
+++ b/R/summarywidget.R
@@ -17,11 +17,14 @@ NULL
 #' @param selection Expression to select a fixed subset of `data`. May be
 #' a logical vector or a one-sided formula that evaluates to a logical vector.
 #' If used, the `key` given to [crosstalk::SharedData] must be a fixed column (not row numbers).
+#' @param digits Shortcut for number of decimal places to display
+#'  (`minimumFractionDigits <- digits` and `maximumFractionDigits <- digits` are
+#'  either added to `localesOptions` or are overwritten).
 #' @param locales A locales string accepted by
+#'  \url{https://www.w3schools.com/jsref/jsref_tolocalestring_number.asp}. If
+#'  `NULL` the preferred language of the user's browser is taken.
+#' @param localesOptions A list of options accepted by
 #'  \url{https://www.w3schools.com/jsref/jsref_tolocalestring_number.asp}.
-#' @param options A list of options accepted by
-#'  \url{https://www.w3schools.com/jsref/jsref_tolocalestring_number.asp}.
-#'  Ignored if `locales` argument is not supplied.
 #' @param width Currently not used.
 #' @param height Currently not used.
 #' @param elementId Currently not used.
@@ -32,8 +35,9 @@ summarywidget <- function(
   statistic = c("count", "sum", "mean"),
   column = NULL,
   selection = NULL,
+  digits = 0,
   locales = NULL,
-  options = NULL,
+  localesOptions = NULL,
   width = NULL,
   height = NULL,
   elementId = NULL
@@ -53,12 +57,18 @@ summarywidget <- function(
 
   statistic <- match.arg(statistic)
 
+  if (!is.null(digits)) {
+    qassert(digits, "N1")
+
+    localesOptions <- as.list(localesOptions)
+    localesOptions$minimumFractionDigits <- digits
+    localesOptions$maximumFractionDigits <- digits
+  }
   if (!is.null(locales)) {
     qassert(locales, "S1")
-
-    if (!is.null(options)) {
-      qassert(options, "L+")
-    }
+  }
+  if (!is.null(localesOptions)) {
+    qassert(localesOptions, "L+")
   }
 
   # If selection is given, apply it
@@ -93,7 +103,7 @@ summarywidget <- function(
     settings = list(
       statistic = statistic,
       locales = locales,
-      options = options,
+      localesOptions = localesOptions,
       crosstalk_key = key,
       crosstalk_group = group
     )

--- a/inst/htmlwidgets/summarywidget.js
+++ b/inst/htmlwidgets/summarywidget.js
@@ -51,7 +51,13 @@ HTMLWidgets.widget({
               break;
           }
 
-          if (x.settings.digits !== null) value = value.toFixed(x.settings.digits);
+          if (x.settings.locales !== null && x.settings.options !== null) {
+            value = value.toLocaleString(x.settings.locales, x.settings.options);
+          } else if (x.settings.locales !== null) {
+            value = value.toLocaleString(x.settings.locales);
+          } else {
+            value = value.toLocaleString();
+          }
           el.innerText = value;
        };
 

--- a/inst/htmlwidgets/summarywidget.js
+++ b/inst/htmlwidgets/summarywidget.js
@@ -51,13 +51,16 @@ HTMLWidgets.widget({
               break;
           }
 
-          if (x.settings.locales !== null && x.settings.options !== null) {
-            value = value.toLocaleString(x.settings.locales, x.settings.options);
+          if (x.settings.locales !== null && x.settings.localesOptions !== null) {
+            value = value.toLocaleString(x.settings.locales, x.settings.localesOptions);
           } else if (x.settings.locales !== null) {
             value = value.toLocaleString(x.settings.locales);
+          } else if (x.settings.localesOptions !== null) {
+            value = value.toLocaleString(navigator.language, x.settings.localesOptions);
           } else {
-            value = value.toLocaleString();
+            value = value.toLocaleString(navigator.language);
           }
+
           el.innerText = value;
        };
 

--- a/inst/htmlwidgets/summarywidget.js
+++ b/inst/htmlwidgets/summarywidget.js
@@ -1,3 +1,11 @@
+function defaultLanguageTag() {
+  if (navigator.language !== "") {
+    return navigator.language;
+  } else {
+    return "en";
+  }
+}
+
 HTMLWidgets.widget({
   name: 'summarywidget',
   type: 'output',
@@ -56,9 +64,9 @@ HTMLWidgets.widget({
           } else if (x.settings.locales !== null) {
             value = value.toLocaleString(x.settings.locales);
           } else if (x.settings.localesOptions !== null) {
-            value = value.toLocaleString(navigator.language, x.settings.localesOptions);
+            value = value.toLocaleString(defaultLanguageTag(), x.settings.localesOptions);
           } else {
-            value = value.toLocaleString(navigator.language);
+            value = value.toLocaleString(defaultLanguageTag());
           }
 
           el.innerText = value;

--- a/man/summarywidget.Rd
+++ b/man/summarywidget.Rd
@@ -4,9 +4,17 @@
 \alias{summarywidget}
 \title{Show a single summary statistic in a widget}
 \usage{
-summarywidget(data, statistic = c("count", "sum", "mean"), column = NULL,
-  selection = NULL, digits = 0, width = NULL, height = NULL,
-  elementId = NULL)
+summarywidget(
+  data,
+  statistic = c("count", "sum", "mean"),
+  column = NULL,
+  selection = NULL,
+  locales = NULL,
+  options = NULL,
+  width = NULL,
+  height = NULL,
+  elementId = NULL
+)
 }
 \arguments{
 \item{data}{Data to summarize, normally an instance of \link[crosstalk:SharedData]{crosstalk::SharedData}.}
@@ -20,14 +28,22 @@ Not used for \code{count} statistic.}
 a logical vector or a one-sided formula that evaluates to a logical vector.
 If used, the \code{key} given to \link[crosstalk:SharedData]{crosstalk::SharedData} must be a fixed column (not row numbers).}
 
-\item{digits}{Number of decimal places to display, or NULL to display full precision.}
+\item{locales}{A locales string accepted by
+\url{https://www.w3schools.com/jsref/jsref_tolocalestring_number.asp}.}
+
+\item{options}{A list of options accepted by
+\url{https://www.w3schools.com/jsref/jsref_tolocalestring_number.asp}.
+Ignored if \code{locales} argument is not supplied.}
+
+\item{width}{Currently not used.}
+
+\item{height}{Currently not used.}
+
+\item{elementId}{Currently not used.}
 }
 \description{
 A \code{summarywidget} displays a single statistic derived from a linked table.
 Its primary use is with the \code{crosstalk} package. Used with \code{crosstalk},
 a \code{summarywidget} displays a value which updates as the data selection
 changes.
-}
-\seealso{
-\url{https://kent37.github.io/summarywidget}
 }

--- a/man/summarywidget.Rd
+++ b/man/summarywidget.Rd
@@ -9,8 +9,9 @@ summarywidget(
   statistic = c("count", "sum", "mean"),
   column = NULL,
   selection = NULL,
+  digits = 0,
   locales = NULL,
-  options = NULL,
+  localesOptions = NULL,
   width = NULL,
   height = NULL,
   elementId = NULL
@@ -28,12 +29,16 @@ Not used for \code{count} statistic.}
 a logical vector or a one-sided formula that evaluates to a logical vector.
 If used, the \code{key} given to \link[crosstalk:SharedData]{crosstalk::SharedData} must be a fixed column (not row numbers).}
 
-\item{locales}{A locales string accepted by
-\url{https://www.w3schools.com/jsref/jsref_tolocalestring_number.asp}.}
+\item{digits}{Shortcut for number of decimal places to display
+(\code{minimumFractionDigits <- digits} and \code{maximumFractionDigits <- digits} are
+either added to \code{localesOptions} or are overwritten).}
 
-\item{options}{A list of options accepted by
-\url{https://www.w3schools.com/jsref/jsref_tolocalestring_number.asp}.
-Ignored if \code{locales} argument is not supplied.}
+\item{locales}{A locales string accepted by
+\url{https://www.w3schools.com/jsref/jsref_tolocalestring_number.asp}. If
+\code{NULL} the preferred language of the user's browser is taken.}
+
+\item{localesOptions}{A list of options accepted by
+\url{https://www.w3schools.com/jsref/jsref_tolocalestring_number.asp}.}
 
 \item{width}{Currently not used.}
 


### PR DESCRIPTION
Hi,

I implemented support for language specific number formats as stated in [my comment](https://github.com/kent37/summarywidget/issues/3#issuecomment-625275603).

It is widely compatible with the existing API/behaviour. The major difference is that if the localisation is not specified, it automatically takes the preferred language of the user's browser.